### PR TITLE
ci(prod): fix ssh-keyscan blocking

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -44,7 +44,7 @@ jobs:
           mkdir -p ~/.ssh
           printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
-          ssh-keyscan -H "$VHOSTING_HOST" >> ~/.ssh/known_hosts 2>/dev/null
+          ssh-keyscan -T 10 "$VHOSTING_HOST" >> ~/.ssh/known_hosts 2>/dev/null || true
 
       - name: Test SSH connection
         run: |


### PR DESCRIPTION
Makes ssh-keyscan non-fatal in deploy-prod.yml; relies on StrictHostKeyChecking=no.